### PR TITLE
Diesel 2.0 Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ version = "0.1.2"
 travis-ci = {repository = "quodlibetor/diesel-derive-newtype", branch = "master"}
 
 [dependencies]
-diesel = {git = "https://github.com/diesel-rs/diesel", rev = "cc8f0b7350347223205f22f40e1e8de1ca442906"}
+diesel = {git = "https://github.com/oeed/diesel", rev = "acd3a9f1cf8e8cfbe6f23535b17a1a44e499e2ce"}
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = "0.14"
 
 [dev-dependencies]
-diesel = {git = "https://github.com/diesel-rs/diesel", rev = "cc8f0b7350347223205f22f40e1e8de1ca442906", features = ["sqlite"]}
+diesel = {git = "https://github.com/oeed/diesel", rev = "acd3a9f1cf8e8cfbe6f23535b17a1a44e499e2ce", features = ["sqlite"]}
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ version = "0.1.2"
 travis-ci = {repository = "quodlibetor/diesel-derive-newtype", branch = "master"}
 
 [dependencies]
-diesel = {git = "https://github.com/oeed/diesel", rev = "acd3a9f1cf8e8cfbe6f23535b17a1a44e499e2ce"}
+diesel = {git = "https://github.com/oeed/diesel", rev = "737d152af383d6f260c1cfe4836c52426cce5a41"}
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = "0.14"
 
 [dev-dependencies]
-diesel = {git = "https://github.com/oeed/diesel", rev = "acd3a9f1cf8e8cfbe6f23535b17a1a44e499e2ce", features = ["sqlite"]}
+diesel = {git = "https://github.com/oeed/diesel", rev = "737d152af383d6f260c1cfe4836c52426cce5a41", features = ["sqlite"]}
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
 categories = ["database", "rust-patterns"]
 description = "Automatically connect newtypes to Diesel using their wrapped type"
+edition = "2018"
 keywords = ["newtype", "derive"]
 license = "Apache-2.0/MIT"
 name = "diesel-derive-newtype"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ travis-ci = { repository = "quodlibetor/diesel-derive-newtype", branch = "master
 proc-macro2 = "0.4"
 syn = "0.14"
 quote = "0.6"
-diesel = "1"
+diesel = { git = "https://github.com/diesel-rs/diesel" }
 
 [dev-dependencies]
-diesel = { version = "1", features = ["sqlite"] }
+diesel = { git = "https://github.com/diesel-rs/diesel", features = ["sqlite"] }
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ version = "0.1.2"
 travis-ci = {repository = "quodlibetor/diesel-derive-newtype", branch = "master"}
 
 [dependencies]
-diesel = {git = "https://github.com/diesel-rs/diesel", rev = "6e46d08d1a745dff513707cada690dac8246cf98"}
+diesel = {git = "https://github.com/diesel-rs/diesel", rev = "9dc434e7f428d4817d8d576c703df5f808056fd6"}
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = "0.14"
 
 [dev-dependencies]
-diesel = {git = "https://github.com/diesel-rs/diesel", rev = "6e46d08d1a745dff513707cada690dac8246cf98", features = ["sqlite"]}
+diesel = {git = "https://github.com/diesel-rs/diesel", rev = "9dc434e7f428d4817d8d576c703df5f808056fd6", features = ["sqlite"]}
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name = "diesel-derive-newtype"
-version = "0.1.2"
 authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
-license = "Apache-2.0/MIT"
-readme = "README.md"
 categories = ["database", "rust-patterns"]
-keywords = ["newtype", "derive"]
 description = "Automatically connect newtypes to Diesel using their wrapped type"
+keywords = ["newtype", "derive"]
+license = "Apache-2.0/MIT"
+name = "diesel-derive-newtype"
+readme = "README.md"
 repository = "https://github.com/quodlibetor/diesel-derive-newtype"
+version = "0.1.2"
 
 [badges]
-travis-ci = { repository = "quodlibetor/diesel-derive-newtype", branch = "master" }
+travis-ci = {repository = "quodlibetor/diesel-derive-newtype", branch = "master"}
 
 [dependencies]
+diesel = {git = "https://github.com/diesel-rs/diesel", rev = "cc8f0b7350347223205f22f40e1e8de1ca442906"}
 proc-macro2 = "0.4"
-syn = "0.14"
 quote = "0.6"
-diesel = { git = "https://github.com/diesel-rs/diesel" }
+syn = "0.14"
 
 [dev-dependencies]
-diesel = { git = "https://github.com/diesel-rs/diesel", features = ["sqlite"] }
+diesel = {git = "https://github.com/diesel-rs/diesel", features = ["sqlite"]}
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ quote = "0.6"
 syn = "0.14"
 
 [dev-dependencies]
-diesel = {git = "https://github.com/diesel-rs/diesel", features = ["sqlite"]}
+diesel = {git = "https://github.com/diesel-rs/diesel", rev = "cc8f0b7350347223205f22f40e1e8de1ca442906", features = ["sqlite"]}
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ version = "0.1.2"
 travis-ci = {repository = "quodlibetor/diesel-derive-newtype", branch = "master"}
 
 [dependencies]
-diesel = {git = "https://github.com/oeed/diesel", rev = "737d152af383d6f260c1cfe4836c52426cce5a41"}
+diesel = {git = "https://github.com/diesel-rs/diesel", rev = "6e46d08d1a745dff513707cada690dac8246cf98"}
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = "0.14"
 
 [dev-dependencies]
-diesel = {git = "https://github.com/oeed/diesel", rev = "737d152af383d6f260c1cfe4836c52426cce5a41", features = ["sqlite"]}
+diesel = {git = "https://github.com/diesel-rs/diesel", rev = "6e46d08d1a745dff513707cada690dac8246cf98", features = ["sqlite"]}
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.1.2"
 travis-ci = {repository = "quodlibetor/diesel-derive-newtype", branch = "master"}
 
 [dependencies]
-diesel = {git = "https://github.com/diesel-rs/diesel", rev = "9dc434e7f428d4817d8d576c703df5f808056fd6"}
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ quote = "0.6"
 syn = "0.14"
 
 [dev-dependencies]
-diesel = {git = "https://github.com/diesel-rs/diesel", rev = "9dc434e7f428d4817d8d576c703df5f808056fd6", features = ["sqlite"]}
+diesel = {git = "https://github.com/diesel-rs/diesel", rev = "4cae65cb02cd1c50cf3173505df497fc32d64d56", features = ["sqlite"]}
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ fn gen_from_sql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
             DB: diesel::backend::Backend,
             DB: diesel::sql_types::HasSqlType<ST>,
         {
-            fn from_sql(raw: Option<&diesel::backend::RawValue<'_, DB>>)
+            fn from_sql(raw: diesel::backend::RawValue<'_, DB>)
             -> ::std::result::Result<Self, Box<::std::error::Error + Send + Sync>>
             {
                 diesel::deserialize::FromSql::<ST, DB>::from_sql(raw)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,8 +250,8 @@ fn gen_queryable(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
         {
             type Row = #wrapped_ty;
 
-            fn build(row: Self::Row) -> Self {
-                #name(row)
+            fn build(row: Self::Row) -> diesel::deserialize::Result<Self> {
+                Ok(#name(row))
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,6 @@ fn wrap_impls_in_const(ty_name: &syn::Ident, item: &TokenStream) -> TokenStream 
     );
     quote! {
         const #dummy_const: () = {
-            extern crate diesel;
             #item
         };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,6 @@
 //! keep in mind that the Diesel methods basically auto-transmute your data into
 //! the underlying SQL type.
 
-
 extern crate syn;
 #[macro_use]
 extern crate quote;
@@ -162,16 +161,19 @@ fn expand_sql_types(ast: &syn::DeriveInput) -> TokenStream {
     // since our query doesn't take varargs it's fine for the DB to cache it
     let query_id_impl = gen_query_id(&name);
 
-    wrap_impls_in_const(name, &quote! {
-        #to_sql_impl
-        #as_expr_impl
+    wrap_impls_in_const(
+        name,
+        &quote! {
+            #to_sql_impl
+            #as_expr_impl
 
-        #from_sql_impl
+            #from_sql_impl
 
-        #queryable_impl
+            #queryable_impl
 
-        #query_id_impl
-    })
+            #query_id_impl
+        },
+    )
 }
 
 fn gen_tosql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
@@ -182,8 +184,7 @@ fn gen_tosql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
             DB: diesel::backend::Backend,
             DB: diesel::sql_types::HasSqlType<ST>,
         {
-            fn to_sql<W: ::std::io::Write>(&self, out: &mut diesel::serialize::Output<W, DB>)
-            -> ::std::result::Result<diesel::serialize::IsNull, Box<::std::error::Error + Send + Sync>>
+            fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, DB>) -> diesel::serialize::Result
             {
                 self.0.to_sql(out)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,17 +176,14 @@ fn expand_sql_types(ast: &syn::DeriveInput) -> TokenStream {
 
 fn gen_tosql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
     quote! {
-        impl<ST, DB> diesel::types::ToSql<ST, DB> for #name
+        impl<ST, DB> diesel::serialize::ToSql<ST, DB> for #name
         where
-            #wrapped_ty: diesel::types::ToSql<ST, DB>,
+            #wrapped_ty: diesel::serialize::ToSql<ST, DB>,
             DB: diesel::backend::Backend,
-            DB: diesel::types::HasSqlType<ST>,
+            DB: diesel::sql_types::HasSqlType<ST>,
         {
-            // TODO: Update this to new types after Diesel 1.1 has been out for 3 months
-            // (around April)
-            #[allow(deprecated)]
-            fn to_sql<W: ::std::io::Write>(&self, out: &mut diesel::types::ToSqlOutput<W, DB>)
-            -> ::std::result::Result<diesel::types::IsNull, Box<::std::error::Error + Send + Sync>>
+            fn to_sql<W: ::std::io::Write>(&self, out: &mut diesel::serialize::Output<W, DB>)
+            -> ::std::result::Result<diesel::serialize::IsNull, Box<::std::error::Error + Send + Sync>>
             {
                 self.0.to_sql(out)
             }
@@ -201,6 +198,7 @@ fn gen_asexpresions(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
         where
             diesel::expression::bound::Bound<ST, #wrapped_ty>:
                 diesel::expression::Expression<SqlType=ST>,
+            ST: diesel::sql_types::SingleValue,
         {
             type Expression = diesel::expression::bound::Bound<ST, #wrapped_ty>;
 
@@ -212,7 +210,8 @@ fn gen_asexpresions(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
         impl<'expr, ST> diesel::expression::AsExpression<ST> for &'expr #name
         where
             diesel::expression::bound::Bound<ST, #wrapped_ty>:
-                diesel::expression::Expression<SqlType=ST>
+                diesel::expression::Expression<SqlType=ST>,
+            ST: diesel::sql_types::SingleValue,
         {
             type Expression = diesel::expression::bound::Bound<ST, &'expr #wrapped_ty>;
 
@@ -225,16 +224,16 @@ fn gen_asexpresions(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
 
 fn gen_from_sql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
     quote! {
-        impl<ST, DB> diesel::types::FromSql<ST, DB> for #name
+        impl<ST, DB> diesel::deserialize::FromSql<ST, DB> for #name
         where
-            #wrapped_ty: diesel::types::FromSql<ST, DB>,
+            #wrapped_ty: diesel::deserialize::FromSql<ST, DB>,
             DB: diesel::backend::Backend,
-            DB: diesel::types::HasSqlType<ST>,
+            DB: diesel::sql_types::HasSqlType<ST>,
         {
-            fn from_sql(raw: Option<&<DB as diesel::backend::Backend>::RawValue>)
+            fn from_sql(raw: Option<&diesel::backend::RawValue<'_, DB>>)
             -> ::std::result::Result<Self, Box<::std::error::Error + Send + Sync>>
             {
-                diesel::types::FromSql::<ST, DB>::from_sql(raw)
+                diesel::deserialize::FromSql::<ST, DB>::from_sql(raw)
                     .map(#name)
             }
         }
@@ -243,11 +242,11 @@ fn gen_from_sql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
 
 fn gen_queryable(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
     quote! {
-        impl<ST, DB> diesel::query_source::Queryable<ST, DB> for #name
+        impl<ST, DB> diesel::deserialize::Queryable<ST, DB> for #name
         where
-            #wrapped_ty: diesel::types::FromSqlRow<ST, DB>,
+            #wrapped_ty: diesel::deserialize::FromStaticSqlRow<ST, DB>,
             DB: diesel::backend::Backend,
-            DB: diesel::types::HasSqlType<ST>,
+            DB: diesel::sql_types::HasSqlType<ST>,
         {
             type Row = #wrapped_ty;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,6 @@ fn expand_sql_types(ast: &syn::DeriveInput) -> TokenStream {
 
     // raw deserialization
     let from_sql_impl = gen_from_sql(&name, &wrapped_ty);
-    let from_sqlrow_impl = gen_from_sqlrow(&name, &wrapped_ty);
 
     // querying
     let queryable_impl = gen_queryable(&name, &wrapped_ty);
@@ -168,7 +167,6 @@ fn expand_sql_types(ast: &syn::DeriveInput) -> TokenStream {
         #as_expr_impl
 
         #from_sql_impl
-        #from_sqlrow_impl
 
         #queryable_impl
 
@@ -238,23 +236,6 @@ fn gen_from_sql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
             {
                 diesel::types::FromSql::<ST, DB>::from_sql(raw)
                     .map(#name)
-            }
-        }
-    }
-}
-
-fn gen_from_sqlrow(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
-    quote! {
-        impl<ST, DB> diesel::types::FromSqlRow<ST, DB> for #name
-        where
-            #wrapped_ty: diesel::types::FromSql<ST, DB>,
-            DB: diesel::backend::Backend,
-            DB: diesel::types::HasSqlType<ST>,
-        {
-            fn build_from_row<R: diesel::row::Row<DB>>(row: &mut R)
-            -> ::std::result::Result<Self, Box<::std::error::Error + Send + Sync>>
-            {
-                diesel::types::FromSql::<ST, DB>::from_sql(row.take())
             }
         }
     }

--- a/tests/db-roundtrips.rs
+++ b/tests/db-roundtrips.rs
@@ -1,11 +1,7 @@
-#[macro_use]
-extern crate diesel;
-#[macro_use]
-extern crate diesel_derive_newtype;
-
 use diesel::dsl::sql;
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
+use diesel_derive_newtype::DieselNewType;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, DieselNewType)]
 pub struct MyId(String);

--- a/tests/db-roundtrips.rs
+++ b/tests/db-roundtrips.rs
@@ -1,15 +1,17 @@
-#[macro_use] extern crate diesel;
-#[macro_use] extern crate diesel_derive_newtype;
+#[macro_use]
+extern crate diesel;
+#[macro_use]
+extern crate diesel_derive_newtype;
 
-use diesel::prelude::*;
 use diesel::dsl::sql;
+use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, DieselNewType)]
 pub struct MyId(String);
 
 #[derive(Debug, Clone, PartialEq, Identifiable, Insertable, Queryable)]
-#[table_name="my_entities"]
+#[table_name = "my_entities"]
 pub struct MyEntity {
     id: MyId,
     val: i32,
@@ -24,48 +26,57 @@ table! {
 
 #[cfg(test)]
 fn setup() -> SqliteConnection {
-    let conn = SqliteConnection::establish(":memory:").unwrap();
+    let mut conn = SqliteConnection::establish(":memory:").unwrap();
     let setup = sql::<diesel::sql_types::Bool>(
         "CREATE TABLE IF NOT EXISTS my_entities (
                 id TEXT PRIMARY KEY,
                 val Int
-         )");
-    setup.execute(&conn).expect("Can't create table");
+         )",
+    );
+    setup.execute(&mut conn).expect("Can't create table");
     conn
 }
 
 #[test]
 fn does_roundtrip() {
-    let conn = setup();
-    let obj = MyEntity { id: MyId("WooHoo".into()), val: 1 };
+    let mut conn = setup();
+    let obj = MyEntity {
+        id: MyId("WooHoo".into()),
+        val: 1,
+    };
 
     diesel::insert_into(my_entities::table)
         .values(&obj)
-        .execute(&conn)
+        .execute(&mut conn)
         .expect("Couldn't insert struct into my_entities");
 
-    let found: Vec<MyEntity> = my_entities::table.load(&conn).unwrap();
+    let found: Vec<MyEntity> = my_entities::table.load(&mut conn).unwrap();
     println!("found: {:?}", found);
     assert_eq!(found[0], obj);
 }
 
-
 #[test]
 fn queryable() {
-    let conn = setup();
+    let mut conn = setup();
     let objs = vec![
-        MyEntity { id: MyId("WooHoo".into()), val: 1 },
-        MyEntity { id: MyId("boo".into()), val: 2 },
+        MyEntity {
+            id: MyId("WooHoo".into()),
+            val: 1,
+        },
+        MyEntity {
+            id: MyId("boo".into()),
+            val: 2,
+        },
     ];
 
     diesel::insert_into(my_entities::table)
         .values(&objs)
-        .execute(&conn)
+        .execute(&mut conn)
         .expect("Couldn't insert struct into my_entities");
 
     let ids: Vec<MyId> = my_entities::table
         .select(my_entities::columns::id)
-        .load(&conn)
+        .load(&mut conn)
         .unwrap();
     assert_eq!(&ids[0], &objs[0].id);
     assert_eq!(&ids[1], &objs[1].id);
@@ -73,71 +84,98 @@ fn queryable() {
 
 #[test]
 fn query_as_id() {
-    let conn = setup();
-    let expected = MyEntity { id: MyId("WooHoo".into()), val: 1 };
+    let mut conn = setup();
+    let expected = MyEntity {
+        id: MyId("WooHoo".into()),
+        val: 1,
+    };
     let objs = vec![
-        MyEntity { id: MyId("loop".into()), val: 0 },
+        MyEntity {
+            id: MyId("loop".into()),
+            val: 0,
+        },
         expected.clone(),
-        MyEntity { id: MyId("boo".into()), val: 2 },
+        MyEntity {
+            id: MyId("boo".into()),
+            val: 2,
+        },
     ];
 
     diesel::insert_into(my_entities::table)
         .values(&objs)
-        .execute(&conn)
+        .execute(&mut conn)
         .expect("Couldn't insert struct into my_entities");
 
     let ids: Vec<MyEntity> = my_entities::table
         .filter(my_entities::id.eq(MyId("WooHoo".into())))
-        .load(&conn)
+        .load(&mut conn)
         .unwrap();
     assert_eq!(ids, vec![expected])
 }
 
 #[test]
 fn query_as_underlying_type() {
-    let conn = setup();
-    let expected = MyEntity { id: MyId("WooHoo".into()), val: 1 };
+    let mut conn = setup();
+    let expected = MyEntity {
+        id: MyId("WooHoo".into()),
+        val: 1,
+    };
     let objs = vec![
-        MyEntity { id: MyId("loop".into()), val: 0 },
+        MyEntity {
+            id: MyId("loop".into()),
+            val: 0,
+        },
         expected.clone(),
-        MyEntity { id: MyId("boo".into()), val: 2 },
+        MyEntity {
+            id: MyId("boo".into()),
+            val: 2,
+        },
     ];
 
     diesel::insert_into(my_entities::table)
         .values(&objs)
-        .execute(&conn)
+        .execute(&mut conn)
         .expect("Couldn't insert struct into my_entities");
 
     let ids: Vec<MyEntity> = my_entities::table
         .filter(my_entities::id.eq("WooHoo".to_string()))
-        .load(&conn)
+        .load(&mut conn)
         .unwrap();
     assert_eq!(ids, vec![expected])
 }
 
 #[test]
 fn set() {
-    let conn = setup();
-    let expected = MyEntity { id: MyId("WooHoo".into()), val: 1 };
+    let mut conn = setup();
+    let expected = MyEntity {
+        id: MyId("WooHoo".into()),
+        val: 1,
+    };
     let objs = vec![
-        MyEntity { id: MyId("loop".into()), val: 0 },
+        MyEntity {
+            id: MyId("loop".into()),
+            val: 0,
+        },
         expected.clone(),
-        MyEntity { id: MyId("boo".into()), val: 2 },
+        MyEntity {
+            id: MyId("boo".into()),
+            val: 2,
+        },
     ];
 
     diesel::insert_into(my_entities::table)
         .values(&objs)
-        .execute(&conn)
+        .execute(&mut conn)
         .expect("Couldn't insert struct into my_entities");
 
     let new_id = MyId("Oh My".into());
     diesel::update(my_entities::table.find(&expected.id))
         .set(my_entities::id.eq(&new_id))
-        .execute(&conn)
+        .execute(&mut conn)
         .unwrap();
     let updated_ids: Vec<MyEntity> = my_entities::table
         .filter(my_entities::id.eq(&new_id))
-        .load(&conn)
+        .load(&mut conn)
         .unwrap();
-    assert_eq!(updated_ids, vec![ MyEntity { id: new_id, val: 1 }])
+    assert_eq!(updated_ids, vec![MyEntity { id: new_id, val: 1 }])
 }

--- a/tests/should-not-compile.rs
+++ b/tests/should-not-compile.rs
@@ -1,11 +1,13 @@
 //! This is a test file that *DOES* compile and pass tests, but which should
 //! not
 
-#[macro_use] extern crate diesel;
-#[macro_use] extern crate diesel_derive_newtype;
+#[macro_use]
+extern crate diesel;
+#[macro_use]
+extern crate diesel_derive_newtype;
 
-use diesel::prelude::*;
 use diesel::dsl::sql;
+use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, DieselNewType)]
@@ -14,9 +16,8 @@ pub struct MyId(String);
 #[derive(Debug, Clone, PartialEq, Eq, Hash, DieselNewType)]
 pub struct OtherId(String);
 
-
 #[derive(Debug, Clone, PartialEq, Identifiable, Insertable, Queryable)]
-#[table_name="my_entities"]
+#[table_name = "my_entities"]
 pub struct MyEntity {
     id: MyId,
     val: i32,
@@ -31,28 +32,38 @@ table! {
 
 #[cfg(test)]
 fn setup() -> SqliteConnection {
-    let conn = SqliteConnection::establish(":memory:").unwrap();
+    let mut conn = SqliteConnection::establish(":memory:").unwrap();
     let setup = sql::<diesel::sql_types::Bool>(
         "CREATE TABLE IF NOT EXISTS my_entities (
                 id TEXT PRIMARY KEY,
                 val Int
-         )");
-    setup.execute(&conn).expect("Can't create table");
+         )",
+    );
+    setup.execute(&mut conn).expect("Can't create table");
     conn
 }
 
 #[cfg(test)]
 fn setup_with_items() -> (SqliteConnection, Vec<MyEntity>) {
-    let conn = setup();
+    let mut conn = setup();
     let objs = vec![
-        MyEntity { id: MyId("loop".into()), val: 0 },
-        MyEntity { id: MyId("WooHoo".into()), val: 1 },
-        MyEntity { id: MyId("boo".into()), val: 2 },
+        MyEntity {
+            id: MyId("loop".into()),
+            val: 0,
+        },
+        MyEntity {
+            id: MyId("WooHoo".into()),
+            val: 1,
+        },
+        MyEntity {
+            id: MyId("boo".into()),
+            val: 2,
+        },
     ];
 
     diesel::insert_into(my_entities::table)
         .values(&objs)
-        .execute(&conn)
+        .execute(&mut conn)
         .expect("Couldn't insert struct into my_entities");
 
     (conn, objs)
@@ -60,23 +71,23 @@ fn setup_with_items() -> (SqliteConnection, Vec<MyEntity>) {
 
 #[test]
 fn query_as_id() {
-    let (conn, _) = setup_with_items();
+    let (mut conn, _) = setup_with_items();
 
     let _: Vec<MyEntity> = my_entities::table
         .filter(my_entities::id.eq(OtherId("WooHoo".into()))) // <-- OTHERID
-        .load(&conn)
+        .load(&mut conn)
         .unwrap();
 }
 
 #[test]
 fn set() {
-    let (conn, objs) = setup_with_items();
+    let (mut conn, objs) = setup_with_items();
 
     let expected = objs[1].clone();
 
-    let new_id = OtherId("Oh My".into());  // <-- OTHERID
+    let new_id = OtherId("Oh My".into()); // <-- OTHERID
     diesel::update(my_entities::table.find(&expected.id))
         .set(my_entities::id.eq(&new_id))
-        .execute(&conn)
+        .execute(&mut conn)
         .unwrap();
 }

--- a/tests/should-not-compile.rs
+++ b/tests/should-not-compile.rs
@@ -1,10 +1,7 @@
 //! This is a test file that *DOES* compile and pass tests, but which should
 //! not
 
-#[macro_use]
-extern crate diesel;
-#[macro_use]
-extern crate diesel_derive_newtype;
+use diesel_derive_newtype::DieselNewType;
 
 use diesel::dsl::sql;
 use diesel::prelude::*;


### PR DESCRIPTION
As mentioned in #13, this crate doesn't currently support the latest version of Diesel, currently living in Diesel's master branch. The primary reason is largely because they've renamed/moved around some modules, but `FromSqlRow` is now also implemented by `Queryable` so it's no longer needed.

I've changed what I needed to get it working in my use cases, I offer no guarantees by any means that it's 100%. As I use it more I'll make changes if problems arise.

I didn't do it, it probably belongs in a different PR, but it'd be nice to also remove the need for `extern crate` and instead use the Rust 2018 methods.