### PR TITLE
Remove diesel dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ travis-ci = { repository = "quodlibetor/diesel-derive-newtype", branch = "master
 proc-macro2 = "0.4"
 syn = "0.14"
 quote = "0.6"
-diesel = "1"
 
 [dev-dependencies]
 diesel = { version = "1", features = ["sqlite"] }


### PR DESCRIPTION
It is not necessary to specify diesel as a prod dependency, because it is only used in tests. This can slightly speed up compilation of our project, because diesel-derive-newtype wont have to wait on diesel, which is very slow to compile.

I tested locally that this still compiles (with cargo check and cargo build), and that tests are still passing (cargo test).

Edit: Sorry, just saw that there is already a PR for this. Please merge that one and close this.