### PR TITLE
Add support for diesel 2.0 RC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ travis-ci = { repository = "quodlibetor/diesel-derive-newtype", branch = "master
 proc-macro2 = "0.4"
 syn = "0.14"
 quote = "0.6"
-diesel = "1"
+diesel = "<=2"
 
 [dev-dependencies]
-diesel = { version = "1", features = ["sqlite"] }
+diesel = { version = "<=2", features = ["sqlite"] }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Re: https://github.com/quodlibetor/diesel-derive-newtype/issues/13

Full transparency I'm still pretty new to Rust so I really have no clue how legit these changes are. That said, I've been working on `diesel` and found [this issue](https://github.com/LemmyNet/lemmy/issues/2234) in the Lemmy project that I thought would be interesting to work on.

Anyway `cargo build && cargo test` passes so maybe this is a straightforward change?