### PR TITLE
Bump syn/quote/proc-macro2 dependencies to v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ repository = "https://github.com/quodlibetor/diesel-derive-newtype"
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-proc-macro2 = "0.4"
-syn = "0.14"
-quote = "0.6"
+proc-macro2 = "1.0.51"
+syn = "1.0.109"
+quote = "1.0.23"
 
 [dev-dependencies]
 diesel = { version = "1", features = ["sqlite"] }


### PR DESCRIPTION
The versions of those crates used by this crate are quite old, and cargo nightly is warning that syn 0.14.9 will be rejected by a future version of Rust:

    ☸ prod-us-central-3 (hosted-grafana) in diesel-derive-newtype on  main is 📦 v1.0.0 via 🦀 v1.67.1
    ❯ cargo +nightly c --future-incompat-report
        Finished dev [unoptimized + debuginfo] target(s) in 0.05s
    warning: the following packages contain code that will be rejected by a future version of Rust: syn v0.14.9
    note:
    To solve this problem, you can try the following approaches:

    - Some affected dependencies have newer versions available.
    You may want to consider updating them to a newer version to see if the issue has been fixed.

    syn v0.14.9 has the following newer versions available: 0.15.0, 0.15.1, 0.15.3, 0.15.4, 0.15.5, 0.15.6, 0.15.7, 0.15.8, 0.15.9, 0.15.10, 0.15.11, 0.15.12, 0.15.13, 0.15.14, 0.15.15, 0.15.16, 0.15.17, 0.15.18, 0.15.19, 0.15.20, 0.15.21, 0.15.22, 0.15.23, 0.15.24, 0.15.25, 0.15.26, 0.15.27, 0.15.28, 0.15.29, 0.15.30, 0.15.31, 0.15.32, 0.15.33, 0.15.34, 0.15.35, 0.15.36, 0.15.37, 0.15.38, 0.15.39, 0.15.40, 0.15.41, 0.15.42, 0.15.43, 0.15.44, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.10, 1.0.11, 1.0.12, 1.0.13, 1.0.14, 1.0.15, 1.0.16, 1.0.17, 1.0.18, 1.0.19, 1.0.20, 1.0.21, 1.0.22, 1.0.23, 1.0.24, 1.0.25, 1.0.26, 1.0.27, 1.0.28, 1.0.29, 1.0.30, 1.0.31, 1.0.32, 1.0.33, 1.0.34, 1.0.35, 1.0.36, 1.0.37, 1.0.38, 1.0.39, 1.0.40, 1.0.41, 1.0.42, 1.0.43, 1.0.44, 1.0.45, 1.0.46, 1.0.47, 1.0.48, 1.0.50, 1.0.51, 1.0.52, 1.0.53, 1.0.54, 1.0.55, 1.0.56, 1.0.57, 1.0.58, 1.0.59, 1.0.60, 1.0.61, 1.0.62, 1.0.63, 1.0.64, 1.0.65, 1.0.66, 1.0.67, 1.0.68, 1.0.69, 1.0.70, 1.0.71, 1.0.72, 1.0.73, 1.0.74, 1.0.75, 1.0.76, 1.0.77, 1.0.78, 1.0.79, 1.0.80, 1.0.81, 1.0.82, 1.0.83, 1.0.84, 1.0.85, 1.0.86, 1.0.87, 1.0.88, 1.0.89, 1.0.90, 1.0.91, 1.0.92, 1.0.93, 1.0.94, 1.0.95, 1.0.96, 1.0.97, 1.0.98, 1.0.99, 1.0.100, 1.0.101, 1.0.102, 1.0.103, 1.0.104, 1.0.105, 1.0.106, 1.0.107, 1.0.108, 1.0.109

    - If the issue is not solved by updating the dependencies, a fix has to be
    implemented by those dependencies. You can help with that by notifying the
    maintainers of this problem (e.g. by creating a bug report) or by proposing a
    fix to the maintainers (e.g. by creating a pull request):

      - syn@0.14.9
      - Repository: https://github.com/dtolnay/syn - Detailed warning command: `cargo report future-incompatibilities --id 2 --package syn@0.14.9`

    - If waiting for an upstream fix is not an option, you can use the `[patch]` section in `Cargo.toml` to use your own version of the dependency. For more information, see: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section

    note: this report can be shown with `cargo report future-incompatibilities --id 1`

This just bumps the dependencies to stable v1 ones, which should also help compile times since other projects tend to use v1 of those dependencies now (including `diesel_derives` itself).