### PR TITLE
Bump syn to 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust_version: [1.52.1, stable, beta]
+        rust_version: [1.56.0, stable, beta]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,15 @@ categories = ["database", "rust-patterns"]
 keywords = ["newtype", "derive"]
 description = "Automatically connect newtypes to Diesel using their wrapped type"
 repository = "https://github.com/quodlibetor/diesel-derive-newtype"
+# Inherited MSRV of `syn`.
+rust-version = "1.56"
 
 [badges]
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
 proc-macro2 = "1.0.51"
-syn = "1.0.109"
+syn = "2.0.10"
 quote = "1.0.23"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ And for Diesel 2.x:
 diesel-derive-newtype = "2.0.0-rc.0"
 ```
 
+Note: this crate requires Rust 1.56 due to the dependency on syn 2.x.
+
 ## `#[derive(DieselNewType)]`
 
 This crate exposes a single custom-derive macro `DieselNewType` which


### PR DESCRIPTION
Followup to
https://github.com/quodlibetor/diesel-derive-newtype/pull/23#issuecomment-1483872801.

I've added an MSRV note to the README and Cargo.toml but don't know if it's really necessary in the Cargo.toml since the MSRV of syn will be picked up by tooling anyway 🤷