### PR TITLE
Merge main into diesel-2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: Rust
 on:
   push:
-    branches: [master]
+    branches: [main, diesel-2]
   pull_request:
-    branches: [master]
+    branches: [main, diesel-2]
 env:
   CARGO_TERM_COLOR: always
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust_version: [1.52.1, stable, beta]
+        rust_version: [1.56.0, stable, beta]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+# 1.0.2
+
+* Update syn to 2.0, bump MSRV to 1.56
+
 # 1.0.1
 
 * Update syn/quote/proc-macro2 dependencies to 1.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.0.1
+
+* Update syn/quote/proc-macro2 dependencies to 1.x
+
+# 1.0.0
+
+* Remove non-dev dependency on `diesel` -- `diesel-derive-newtype` generates generic diesel code.
+  If a future release of Diesel breaks compatibility with `diesel-derive-newtype` an explicit
+  dependency on the correct version span will be added and a new release will be made.
+* CI improvements.
+
 # 0.1.1
 
 Bugs Fixed:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-derive-newtype"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
 license = "Apache-2.0/MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,15 @@ categories = ["database", "rust-patterns"]
 keywords = ["newtype", "derive"]
 description = "Automatically connect newtypes to Diesel using their wrapped type"
 repository = "https://github.com/quodlibetor/diesel-derive-newtype"
+# Inherited MSRV of `syn`.
+rust-version = "1.56"
 
 [badges]
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
 proc-macro2 = "1.0.51"
-syn = "1.0.109"
+syn = "2.0.10"
 quote = "1.0.23"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-derive-newtype"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
 license = "Apache-2.0/MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ repository = "https://github.com/quodlibetor/diesel-derive-newtype"
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-proc-macro2 = "0.4"
-syn = "0.14"
-quote = "0.6"
+proc-macro2 = "1.0.51"
+syn = "1.0.109"
+quote = "1.0.23"
 
 [dev-dependencies]
 diesel = { version = "1", features = ["sqlite"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-derive-newtype"
-version = "0.2.0"
+version = "1.0.0"
 authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
 license = "Apache-2.0/MIT"
 readme = "README.md"
@@ -10,7 +10,7 @@ description = "Automatically connect newtypes to Diesel using their wrapped type
 repository = "https://github.com/quodlibetor/diesel-derive-newtype"
 
 [badges]
-travis-ci = { repository = "quodlibetor/diesel-derive-newtype", branch = "master" }
+maintenance = { status = "passively-maintained" }
 
 [dependencies]
 proc-macro2 = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ travis-ci = { repository = "quodlibetor/diesel-derive-newtype", branch = "master
 proc-macro2 = "0.4"
 syn = "0.14"
 quote = "0.6"
-diesel = "1"
 
 [dev-dependencies]
 diesel = { version = "1", features = ["sqlite"] }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ Easy-peasy support of newtypes inside of Diesel.
 
 [![Rust](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml/badge.svg)](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml) [![Crates.io Version](https://img.shields.io/crates/v/diesel-derive-newtype.svg)](https://crates.io/crates/diesel-derive-newtype)
 
+## Installation
+
+diesel-derive-newtype supports Diesel according to its major version -- 0.x
+through 1.x support the corresponding diesel versions, 2.x supports diesel 2.x.
+
+So for Diesel 1.x:
+
+```toml
+[dependencies]
+diesel-derive-newtype = "1.0"
+```
+
+And for Diesel 2.x:
+
+```toml
+[dependencies]
+diesel-derive-newtype = "2.0.0-rc.0"
+```
+
 ## `#[derive(DieselNewType)]`
 
 This crate exposes a single custom-derive macro `DieselNewType` which
@@ -112,16 +131,6 @@ I hope to find a solution that doesn't involve implementing every
 `*Expression` trait manually with an extra bound, but for now you have to
 keep in mind that the Diesel methods basically auto-transmute your data into
 the underlying SQL type.
-
-## Installation
-
-diesel-derive-newtype supports Diesel according to its major version -- 0.x
-through 1.x support the corresponding diesel versions, 2.x supports diesel 2.x.
-
-```toml
-[dependencies]
-diesel-derive-newtype = "1.0"
-```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Easy-peasy support of newtypes inside of Diesel.
 
-[![Build Status](https://travis-ci.org/quodlibetor/diesel-derive-newtype.svg?branch=master)](https://travis-ci.org/quodlibetor/diesel-derive-newtype) [![Crates.io Version](https://img.shields.io/crates/v/diesel-derive-newtype.svg)](https://crates.io/crates/diesel-derive-newtype)
+[![Rust](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml/badge.svg)](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml) [![Crates.io Version](https://img.shields.io/crates/v/diesel-derive-newtype.svg)](https://crates.io/crates/diesel-derive-newtype)
 
 ## `#[derive(DieselNewType)]`
 
@@ -115,11 +115,12 @@ the underlying SQL type.
 
 ## Installation
 
-diesel-derive-newtype supports Diesel 0.16 - 0.99.
+diesel-derive-newtype supports Diesel according to its major version -- 0.x
+through 1.x support the corresponding diesel versions, 2.x supports diesel 2.x.
 
 ```toml
 [dependencies]
-diesel-derive-newtype = "0.1"
+diesel-derive-newtype = "1.0"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ And for Diesel 2.x:
 diesel-derive-newtype = "2.0.0-rc.0"
 ```
 
+Note: this crate requires Rust 1.56 due to the dependency on syn 2.x.
+
 ## `#[derive(DieselNewType)]`
 
 This crate exposes a single custom-derive macro `DieselNewType` which

--- a/README.tpl
+++ b/README.tpl
@@ -2,17 +2,18 @@
 
 Easy-peasy support of newtypes inside of Diesel.
 
-[![Build Status](https://travis-ci.org/quodlibetor/diesel-derive-newtype.svg?branch=master)](https://travis-ci.org/quodlibetor/diesel-derive-newtype) [![Crates.io Version](https://img.shields.io/crates/v/diesel-derive-newtype.svg)](https://crates.io/crates/diesel-derive-newtype)
+[![Rust](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml/badge.svg)](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml) [![Crates.io Version](https://img.shields.io/crates/v/diesel-derive-newtype.svg)](https://crates.io/crates/diesel-derive-newtype)
 
 {{readme}}
 
 ## Installation
 
-diesel-derive-newtype supports Diesel 0.16 - 0.99.
+diesel-derive-newtype supports Diesel according to its major version -- 0.x
+through 1.x support the corresponding diesel versions, 2.x supports diesel 2.x.
 
 ```toml
 [dependencies]
-diesel-derive-newtype = "0.1"
+diesel-derive-newtype = "1.0"
 ```
 
 ## License

--- a/README.tpl
+++ b/README.tpl
@@ -4,17 +4,26 @@ Easy-peasy support of newtypes inside of Diesel.
 
 [![Rust](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml/badge.svg)](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml) [![Crates.io Version](https://img.shields.io/crates/v/diesel-derive-newtype.svg)](https://crates.io/crates/diesel-derive-newtype)
 
-{{readme}}
-
 ## Installation
 
 diesel-derive-newtype supports Diesel according to its major version -- 0.x
 through 1.x support the corresponding diesel versions, 2.x supports diesel 2.x.
 
+So for Diesel 1.x:
+
 ```toml
 [dependencies]
 diesel-derive-newtype = "1.0"
 ```
+
+And for Diesel 2.x:
+
+```toml
+[dependencies]
+diesel-derive-newtype = "2.0.0-rc.0"
+```
+
+{{readme}}
 
 ## License
 


### PR DESCRIPTION
The diesel-2 branch was a little bit behind, this brings it back up to date. It's mostly README and CI stuff with a few conflicts, but more importantly this includes the syn upgrades.