### PR TITLE
Update for Diesel 2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust_version: [1.56.0, stable, beta]
+        rust_version: [1.65.0, stable, beta]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ quote = "1.0.23"
 maintenance = { status = "passively-maintained" }
 
 [dev-dependencies]
-diesel = {version = "2.0.0", features = ["sqlite"]}
+diesel = {version = "2.1.0", features = ["sqlite"]}
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0/MIT"
 readme = "README.md"
 repository = "https://github.com/quodlibetor/diesel-derive-newtype"
 # Inherited MSRV of `syn`.
-rust-version = "1.56"
+rust-version = "1.65"
 
 [dependencies]
 proc-macro2 = "1.0.51"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ quote = "1.0.23"
 maintenance = { status = "passively-maintained" }
 
 [dev-dependencies]
-diesel = {version = "2.1.0", features = ["sqlite"]}
+diesel = { version = "2.1.0", features = ["sqlite"], default-features = false }
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ fn gen_from_sql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
             DB: diesel::backend::Backend,
             DB: diesel::sql_types::HasSqlType<ST>,
         {
-            fn from_sql(raw: diesel::backend::RawValue<'_, DB>)
+            fn from_sql(raw: DB::RawValue<'_>)
             -> ::std::result::Result<Self, Box<::std::error::Error + Send + Sync>>
             {
                 diesel::deserialize::FromSql::<ST, DB>::from_sql(raw)


### PR DESCRIPTION
I'm not sure about the rust-version update, but tests failed with 1.56 because it couldn't find diesel 2.1