### PR TITLE
Fix warnings about `non_local_definitions`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,17 +149,17 @@ fn expand_sql_types(ast: &syn::DeriveInput) -> TokenStream {
     };
 
     // Required to be able to insert/read from the db, don't allow searching
-    let to_sql_impl = gen_tosql(&name, &wrapped_ty);
-    let as_expr_impl = gen_asexpressions(&name, &wrapped_ty);
+    let to_sql_impl = gen_tosql(name, wrapped_ty);
+    let as_expr_impl = gen_asexpressions(name, wrapped_ty);
 
     // raw deserialization
-    let from_sql_impl = gen_from_sql(&name, &wrapped_ty);
+    let from_sql_impl = gen_from_sql(name, wrapped_ty);
 
     // querying
-    let queryable_impl = gen_queryable(&name, &wrapped_ty);
+    let queryable_impl = gen_queryable(name, wrapped_ty);
 
     // since our query doesn't take varargs it's fine for the DB to cache it
-    let query_id_impl = gen_query_id(&name);
+    let query_id_impl = gen_query_id(name);
 
     wrap_impls_in_const(&quote! {
         #to_sql_impl

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,19 +161,16 @@ fn expand_sql_types(ast: &syn::DeriveInput) -> TokenStream {
     // since our query doesn't take varargs it's fine for the DB to cache it
     let query_id_impl = gen_query_id(&name);
 
-    wrap_impls_in_const(
-        name,
-        &quote! {
-            #to_sql_impl
-            #as_expr_impl
+    wrap_impls_in_const(&quote! {
+        #to_sql_impl
+        #as_expr_impl
 
-            #from_sql_impl
+        #from_sql_impl
 
-            #queryable_impl
+        #queryable_impl
 
-            #query_id_impl
-        },
-    )
+        #query_id_impl
+    })
 }
 
 fn gen_tosql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
@@ -279,15 +276,9 @@ fn gen_query_id(name: &syn::Ident) -> TokenStream {
     }
 }
 
-/// This guarantees that items we generate don't polute the module scope
-///
-/// We use the const name as a form of documentation of the generated code
-fn wrap_impls_in_const(ty_name: &syn::Ident, item: &TokenStream) -> TokenStream {
-    let name = ty_name.to_string().to_uppercase();
-    let dummy_const = syn::Ident::new(
-        &format!("_IMPL_DIESEL_NEW_TYPE_FOR_{}", name),
-        Span::call_site(),
-    );
+/// This guarantees that items we generate don't pollute the module scope
+fn wrap_impls_in_const(item: &TokenStream) -> TokenStream {
+    let dummy_const = syn::Ident::new("_", Span::call_site());
     quote! {
         const #dummy_const: () = {
             #item


### PR DESCRIPTION
This PR changes named constant block to anon-const so rustc doesn't warn about `non_local_definitions` _(and makes minor fixes suggested by clippy)_

**Details:**
Recent nightly versions implement https://github.com/rust-lang/rust/pull/120393 which causes compilation warnings like

```
warning: non-local `impl` definition, they should be avoided as they go against expectation
 --> src/containers/password.rs:8:38
  |
8 | #[cfg_attr(feature = "pgsql", derive(diesel_derive_newtype::DieselNewType))]
  |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: move this `impl` block outside the of the current constant `_IMPL_DIESEL_NEW_TYPE_FOR_PASSWORD`
  = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
  = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
  = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
  = note: the derive macro `diesel_derive_newtype::DieselNewType` may come from an old version of the `diesel_derive_newtype` crate, try updating your dependency with `cargo update -p diesel_derive_newtype`
  = note: `#[warn(non_local_definitions)]` on by default
  = note: this warning originates in the derive macro `diesel_derive_newtype::DieselNewType` (in Nightly builds, run with -Z macro-backtrace for more info)
```

**As warning states, this lint might become `deny-by-default` in the future.**
Only exception to this rule are anon-const which are used also by `serde` to be compatible with different rust editions [more info here](https://github.com/rust-lang/rfcs/pull/3373#issuecomment-1885307786).






