### PR TITLE
bump rust msrv to 1.84 to support latest diesel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust_version: [1.78.0, stable, beta]
+        rust_version: [1.84.0, stable, beta]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust_version: [1.65.0, stable, beta]
+        rust_version: [1.78.0, stable, beta]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 **/*.rs.bk
 Cargo.lock
 README.html
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ target/
 **/*.rs.bk
 Cargo.lock
 README.html
-
-.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["newtype", "derive"]
 license = "Apache-2.0/MIT"
 readme = "README.md"
 repository = "https://github.com/quodlibetor/diesel-derive-newtype"
-# Inherited MSRV of `syn`.
-rust-version = "1.65"
+# Inherited MSRV of `dsl_auto_type`.
+rust-version = "1.78.0"
 
 [dependencies]
 proc-macro2 = "1.0.51"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["newtype", "derive"]
 license = "Apache-2.0/MIT"
 readme = "README.md"
 repository = "https://github.com/quodlibetor/diesel-derive-newtype"
-# Inherited MSRV of `dsl_auto_type`.
-rust-version = "1.78.0"
+# Inherited MSRV of `diesel`.
+rust-version = "1.84.0"
 
 [dependencies]
 proc-macro2 = "1.0.51"


### PR DESCRIPTION
fixes the following build error: https://github.com/quodlibetor/diesel-derive-newtype/actions/runs/14909210326/job/41879048842#step:5:33

while that error had issues requiring at least `1.78`, i ran into the latest diesel requiring at least `1.84` right after https://github.com/diesel-rs/diesel/blob/master/Cargo.toml#L39 (which broke the sqlite tests without it)