### PR TITLE
Support `#[diesel_newtype(try_from)]` and some other ergo improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,23 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+  # The trybuild compile-fail tests snapshot exact compiler output, which drifts
+  # between rustc versions, so they run only on the pinned MSRV toolchain (the
+  # one their `.stderr` files were generated against) rather than the matrix.
+  ui:
+    name: UI compile-fail tests (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.84.0
+          override: true
+      - name: Compile-fail tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features ui --test compile-fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+* Add `#[diesel_newtype(try_from = InnerType)]` to build newtypes fallibly when
+  reading from the database, so type invariants can be upheld
+  ([#12](https://github.com/quodlibetor/diesel-derive-newtype/issues/12)). The
+  read path deserializes `InnerType` and calls `.try_into()`; the conversion
+  error is preserved (must be convertible into `Box<dyn Error + Send + Sync>`).
+  Infallible `From` conversions work too. The write path is unchanged. A bare
+  `#[diesel_newtype(try_from)]` is shorthand for `try_from = <field type>`, the
+  common case.
+
 # Version 2.1.2
 
 * Fix new non_local_definitions lint in nightly (#31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   Infallible `From` conversions work too. The write path is unchanged. A bare
   `#[diesel_newtype(try_from)]` is shorthand for `try_from = <field type>`, the
   common case.
+* Better error messages: applying the derive to something other than a
+  single-field tuple struct (an enum, a named-field struct, wrong field count,
+  etc.), or writing an empty `#[diesel_newtype]`/`#[diesel_newtype()]`, now
+  produces a clear compile error pointing at the offending code instead of a
+  proc-macro panic or an opaque parser error. Named single-field structs are
+  now rejected explicitly (they previously emitted code that failed to compile).
 
 # Version 2.1.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,18 @@ quote = "1.0.23"
 [badges]
 maintenance = { status = "passively-maintained" }
 
+[features]
+# Opt-in `trybuild` UI tests that snapshot the derive's compile errors. Their
+# `.stderr` files are pinned to the MSRV toolchain (rustc 1.84.0) and drift on
+# other versions, so they are gated out of the default `cargo test` and the
+# stable/beta CI matrix; a dedicated 1.84.0 job runs `cargo test --features ui`.
+# Regenerate after intentional message changes with:
+#   TRYBUILD=overwrite cargo +1.84.0 test --features ui
+ui = []
+
 [dev-dependencies]
 diesel = { version = "2.1.0", features = ["sqlite"], default-features = false }
+trybuild = "1.0"
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 repository = "https://github.com/quodlibetor/diesel-derive-newtype"
 # Inherited MSRV of `diesel`.
 rust-version = "1.84.0"
+# MSRV-aware dependency resolution: prefer dep versions compatible with
+# rust-version above, so a fresh resolve on 1.84 (e.g. CI, which does not commit
+# Cargo.lock) does not pull in deps that need a newer toolchain or edition.
+resolver = "3"
 
 [dependencies]
 proc-macro2 = "1.0.51"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,47 @@ See [the tests][] for a more complete example.
 
 [the tests]: https://github.com/quodlibetor/diesel-derive-newtype/blob/master/tests/db-roundtrips.rs
 
+## Upholding invariants when reading (`try_from`)
+
+By default the derive builds your newtype by wrapping the value read from
+the database directly, which means an invalid value in the database becomes
+an invalid instance of your type. If your newtype has invariants (for
+example a private field that only accepts some values), add
+`#[diesel_newtype(try_from = InnerType)]`. The read path (`FromSql` and
+`Queryable`) will then deserialize `InnerType` and call `.try_into()` to
+build your newtype, so construction can fail:
+
+```rust
+#[derive(Debug, PartialEq, Eq, Hash, DieselNewType)]
+#[diesel_newtype(try_from = i32)]
+pub struct Even(i32); // private inner field upholds an invariant; try_from applies it on DB reads
+
+#[derive(Debug)]
+pub struct NotEven(i32);
+impl std::error::Error for NotEven {}
+
+impl TryFrom<i32> for Even {
+    type Error = NotEven;
+    fn try_from(v: i32) -> Result<Self, NotEven> {
+        if v % 2 == 0 { Ok(Even(v)) } else { Err(NotEven(v)) }
+    }
+}
+```
+
+Notes:
+
+* The conversion accepts any type reachable via `.try_into()`, so an
+  infallible `From<InnerType>` works too (its `TryFrom` error is
+  `Infallible`).
+* The `TryFrom` error is preserved, not stringified: it must be convertible
+  into `Box<dyn std::error::Error + Send + Sync>` (i.e. implement
+  `std::error::Error + Send + Sync + 'static`).
+* Only the read path is affected. The write path (`ToSql`, `AsExpression`)
+  always serializes the inner field directly, so no `Clone`/`Into` bound is
+  required and borrowed inserts keep working.
+* This does *not* close the [type hole](#limitations) below: you can still
+  filter a column by the raw underlying SQL type.
+
 ## Limitations
 [limitations]: #limitations
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ diesel-derive-newtype supports Diesel according to its major version -- 0.x
 through 1.x support the corresponding diesel versions, 2.0 supports diesel 2.0,
 and 2.1 supports 2.1. Generally new versions of diesel-derive-newtype are
 released when compilation or tests are observed to fail with a newer version
-of diesel, so newer versions of diesel than the released version of 
+of diesel, so newer versions of diesel than the released version of
 diesel-derive-newtype *may* work. Bug reports and PRs welcome.
 
 New features are only developed for the currently supported version of Diesel.
+
 
 ```toml
 [dependencies]

--- a/README.tpl
+++ b/README.tpl
@@ -4,11 +4,21 @@ Easy-peasy support of newtypes inside of Diesel.
 
 [![Rust](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml/badge.svg?branch=diesel-2)](https://github.com/quodlibetor/diesel-derive-newtype/actions/workflows/test.yml) [![Crates.io Version](https://img.shields.io/crates/v/diesel-derive-newtype.svg)](https://crates.io/crates/diesel-derive-newtype)
 
+### Status
+
+diesel-derive-newtype is small and basically complete -- except for some features
+that aren't supported by Diesel (see "limitations", below). Additionally, I don't
+use diesel on a daily basis any more, so most maintenance comes from bug reports
+or PRs, please open them!
+
 ## Installation
 
 diesel-derive-newtype supports Diesel according to its major version -- 0.x
 through 1.x support the corresponding diesel versions, 2.0 supports diesel 2.0,
-and 2.1 supports 2.1.
+and 2.1 supports 2.1. Generally new versions of diesel-derive-newtype are
+released when compilation or tests are observed to fail with a newer version
+of diesel, so newer versions of diesel than the released version of
+diesel-derive-newtype *may* work. Bug reports and PRs welcome.
 
 New features are only developed for the currently supported version of Diesel.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,49 @@
 //!
 //! [the tests]: https://github.com/quodlibetor/diesel-derive-newtype/blob/master/tests/db-roundtrips.rs
 //!
+//! # Upholding invariants when reading (`try_from`)
+//!
+//! By default the derive builds your newtype by wrapping the value read from
+//! the database directly, which means an invalid value in the database becomes
+//! an invalid instance of your type. If your newtype has invariants (for
+//! example a private field that only accepts some values), add
+//! `#[diesel_newtype(try_from = InnerType)]` or `#[diesel_newtype(try_from)]`
+//! if the from type is identical to the type in the newtype. The read path
+//! (`FromSql` and `Queryable`) will then deserialize into `InnerType` and call
+//! `.try_into()` to build your newtype, so construction can fail:
+//!
+//! ```
+//! # use std::convert::TryFrom;
+//! # use diesel_derive_newtype::DieselNewType;
+//! #[derive(Debug, PartialEq, Eq, Hash, DieselNewType)]
+//! #[diesel_newtype(try_from = i32)]
+//! pub struct Even(i32); // private inner field upholds an invariant; try_from applies it on DB reads
+//!
+//! #[derive(Debug)]
+//! pub struct NotEvenError(i32);
+//! # impl std::fmt::Display for NotEvenError {
+//! #     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { write!(f, "not even") }
+//! # }
+//! impl std::error::Error for NotEvenError {}
+//!
+//! impl TryFrom<i32> for Even {
+//!     type Error = NotEvenError;
+//!     fn try_from(v: i32) -> Result<Self, NotEvenError> {
+//!         if v % 2 == 0 { Ok(Even(v)) } else { Err(NotEvenError(v)) }
+//!     }
+//! }
+//! # fn main() {}
+//! ```
+//!
+//! Notes:
+//!
+//! * The conversion accepts any type reachable via `.try_into()`, so an
+//!   infallible `From<InnerType>` works too.
+//! * The `TryFrom` error is cast into `Box<dyn std::error::Error + Send +
+//!   Sync>`, it must implement `std::error::Error + Send + Sync + 'static`.
+//! * Only the read path is affected. The write path (`ToSql`, `AsExpression`)
+//!   always serializes the inner field directly.
+//!
 //! # Limitations
 //! [limitations]: #limitations
 //!
@@ -125,15 +168,17 @@ extern crate proc_macro2;
 
 use proc_macro2::{Span, TokenStream};
 
-#[proc_macro_derive(DieselNewType)]
+#[proc_macro_derive(DieselNewType, attributes(diesel_newtype))]
 #[doc(hidden)]
 pub fn diesel_new_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
 
-    expand_sql_types(&ast).into()
+    expand_sql_types(&ast)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
-fn expand_sql_types(ast: &syn::DeriveInput) -> TokenStream {
+fn expand_sql_types(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
     let wrapped_ty = match ast.data {
         syn::Data::Struct(ref data) => {
@@ -148,20 +193,31 @@ fn expand_sql_types(ast: &syn::DeriveInput) -> TokenStream {
         _ => panic!("#[derive(DieselNewType)] can only be used with structs with a single field"),
     };
 
-    // Required to be able to insert/read from the db, don't allow searching
+    // `None` = wrap the inner value directly; `Some(ty)` = deserialize `ty` and
+    // `.try_into()` the newtype. A bare `try_from` defaults `ty` to the field
+    // type, which is the usual case.
+    let from_ty = match parse_try_from(ast)? {
+        TryFromAttr::None => None,
+        TryFromAttr::Bare => Some(wrapped_ty.clone()),
+        TryFromAttr::InnerType(ty) => Some(ty),
+    };
+
+    // Required to be able to insert/read from the db, don't allow searching.
+    // The write path always serializes the inner field directly, so it is
+    // unaffected by `try_from` (and needs no `Clone`/`Into`, unlike serde).
     let to_sql_impl = gen_tosql(name, wrapped_ty);
     let as_expr_impl = gen_asexpressions(name, wrapped_ty);
 
     // raw deserialization
-    let from_sql_impl = gen_from_sql(name, wrapped_ty);
+    let from_sql_impl = gen_from_sql(name, wrapped_ty, from_ty.as_ref());
 
     // querying
-    let queryable_impl = gen_queryable(name, wrapped_ty);
+    let queryable_impl = gen_queryable(name, wrapped_ty, from_ty.as_ref());
 
     // since our query doesn't take varargs it's fine for the DB to cache it
     let query_id_impl = gen_query_id(name);
 
-    wrap_impls_in_const(&quote! {
+    Ok(wrap_impls_in_const(&quote! {
         #to_sql_impl
         #as_expr_impl
 
@@ -170,7 +226,56 @@ fn expand_sql_types(ast: &syn::DeriveInput) -> TokenStream {
         #queryable_impl
 
         #query_id_impl
-    })
+    }))
+}
+
+// Built and consumed exactly once per derive expansion, so the size gap between
+// the unit variants and `InnerType`'s `syn::Type` is irrelevant here.
+#[expect(clippy::large_enum_variant)]
+enum TryFromAttr {
+    /// no `try_from`: wrap the inner type with no constructor
+    None,
+    /// bare `#[diesel_newtype(try_from)]`: deserialize the newtype's own field type
+    /// and `.try_into()` it (the common case, where the intermediate type *is*
+    /// the wrapped type).
+    Bare,
+    /// `#[diesel_newtype(try_from = Ty)]`: deserialize `Ty` and `.try_into()` it.
+    InnerType(syn::Type),
+}
+
+/// Parses `#[diesel_newtype(try_from = SomeType)]` or a bare `#[diesel_newtype(try_from)]`.
+///
+/// `.try_into()` upholds invariants on the read path; the infallible
+/// `From` case is covered too, via the std blanket `Into` -> `TryInto` impls.
+fn parse_try_from(ast: &syn::DeriveInput) -> syn::Result<TryFromAttr> {
+    let mut try_from = TryFromAttr::None;
+    for attr in &ast.attrs {
+        if !attr.path().is_ident("diesel_newtype") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("try_from") {
+                if !matches!(try_from, TryFromAttr::None) {
+                    return Err(meta.error("duplicate `try_from` in #[diesel_newtype(...)]"));
+                }
+                // A bare `try_from` is terminated by `,` or the end of the
+                // attribute; anything else must be `try_from = Type`, and
+                // `meta.value()` reports a pointed "expected `=`" if the
+                // separator is wrong (rather than a downstream "expected `,`").
+                try_from = if meta.input.is_empty() || meta.input.peek(syn::Token![,]) {
+                    TryFromAttr::Bare
+                } else {
+                    TryFromAttr::InnerType(meta.value()?.parse::<syn::Type>()?)
+                };
+                Ok(())
+            } else {
+                Err(meta.error(
+                    "unsupported #[diesel_newtype(...)] key, expected `try_from` or `try_from = Type`",
+                ))
+            }
+        })?;
+    }
+    Ok(try_from)
 }
 
 fn gen_tosql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
@@ -233,36 +338,64 @@ fn gen_asexpressions(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
     }
 }
 
-fn gen_from_sql(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
+/// Builds the newtype from a value bound to `inner`: with `try_from`, a fallible
+/// `try_into()` that preserves the conversion error (via `Into` into diesel's
+/// boxed error); without it, a direct wrap. Shared by `FromSql` and `Queryable`
+/// so the conversion semantics live in exactly one place.
+fn gen_build_from_inner(name: &syn::Ident, try_from: Option<&syn::Type>) -> TokenStream {
+    match try_from {
+        Some(_) => quote! {
+            ::std::convert::TryInto::try_into(inner)
+                .map_err(::std::convert::Into::into)
+        },
+        None => quote! { ::std::result::Result::Ok(#name(inner)) },
+    }
+}
+
+fn gen_from_sql(
+    name: &syn::Ident,
+    wrapped_ty: &syn::Type,
+    try_from: Option<&syn::Type>,
+) -> TokenStream {
+    // When `try_from` is set, deserialize the intermediate type rather than the
+    // inner field type; otherwise they're the same.
+    let from_ty = try_from.unwrap_or(wrapped_ty);
+    let build = gen_build_from_inner(name, try_from);
     quote! {
         impl<ST, DB> diesel::deserialize::FromSql<ST, DB> for #name
         where
-            #wrapped_ty: diesel::deserialize::FromSql<ST, DB>,
+            #from_ty: diesel::deserialize::FromSql<ST, DB>,
             DB: diesel::backend::Backend,
             DB: diesel::sql_types::HasSqlType<ST>,
         {
-            fn from_sql(raw: DB::RawValue<'_>)
-            -> ::std::result::Result<Self, Box<::std::error::Error + Send + Sync>>
+            fn from_sql(raw: DB::RawValue<'_>) -> diesel::deserialize::Result<Self>
             {
-                diesel::deserialize::FromSql::<ST, DB>::from_sql(raw)
-                    .map(#name)
+                let inner: #from_ty =
+                    diesel::deserialize::FromSql::<ST, DB>::from_sql(raw)?;
+                #build
             }
         }
     }
 }
 
-fn gen_queryable(name: &syn::Ident, wrapped_ty: &syn::Type) -> TokenStream {
+fn gen_queryable(
+    name: &syn::Ident,
+    wrapped_ty: &syn::Type,
+    try_from: Option<&syn::Type>,
+) -> TokenStream {
+    let from_ty = try_from.unwrap_or(wrapped_ty);
+    let build = gen_build_from_inner(name, try_from);
     quote! {
         impl<ST, DB> diesel::deserialize::Queryable<ST, DB> for #name
         where
-            #wrapped_ty: diesel::deserialize::FromStaticSqlRow<ST, DB>,
+            #from_ty: diesel::deserialize::FromStaticSqlRow<ST, DB>,
             DB: diesel::backend::Backend,
             DB: diesel::sql_types::HasSqlType<ST>,
         {
-            type Row = #wrapped_ty;
+            type Row = #from_ty;
 
-            fn build(row: Self::Row) -> diesel::deserialize::Result<Self> {
-                Ok(#name(row))
+            fn build(inner: Self::Row) -> diesel::deserialize::Result<Self> {
+                #build
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,27 +171,15 @@ use proc_macro2::{Span, TokenStream};
 #[proc_macro_derive(DieselNewType, attributes(diesel_newtype))]
 #[doc(hidden)]
 pub fn diesel_new_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let ast = syn::parse(input).unwrap();
-
-    expand_sql_types(&ast)
+    syn::parse(input)
+        .and_then(|ast| expand_sql_types(&ast))
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }
 
 fn expand_sql_types(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
     let name = &ast.ident;
-    let wrapped_ty = match ast.data {
-        syn::Data::Struct(ref data) => {
-            let mut iter = data.fields.iter();
-            match (iter.next(), iter.next()) {
-                (Some(field), None) => &field.ty,
-                (_, _) => panic!(
-                    "#[derive(DieselNewType)] can only be used with structs with exactly one field"
-                ),
-            }
-        }
-        _ => panic!("#[derive(DieselNewType)] can only be used with structs with a single field"),
-    };
+    let wrapped_ty = validate_wrapped_type(ast)?;
 
     // `None` = wrap the inner value directly; `Some(ty)` = deserialize `ty` and
     // `.try_into()` the newtype. A bare `try_from` defaults `ty` to the field
@@ -229,6 +217,30 @@ fn expand_sql_types(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
     }))
 }
 
+/// Construct an error if the targetted type is not a newtype.
+///
+/// `#[derive(DieselNewType)]` only makes sense for a single-field tuple struct
+/// so reject anything else with a pointed error rather than emitting code that
+/// fails to compile downstream.
+fn validate_wrapped_type(ast: &syn::DeriveInput) -> syn::Result<&syn::Type> {
+    const HELP: &str = "#[derive(DieselNewType)] can only be used on a tuple \
+        struct with exactly one field, e.g. `struct Foo(i64);`";
+    let data = match &ast.data {
+        syn::Data::Struct(data) => data,
+        // enum / union: span the name so the error points at the type.
+        syn::Data::Enum(_) | syn::Data::Union(_) => {
+            return Err(syn::Error::new_spanned(&ast.ident, HELP))
+        }
+    };
+    match &data.fields {
+        syn::Fields::Unnamed(fields) if fields.unnamed.len() == 1 => Ok(&fields.unnamed[0].ty),
+        // unit struct has no fields to point at, so span the name instead.
+        syn::Fields::Unit => Err(syn::Error::new_spanned(&ast.ident, HELP)),
+        // wrong field count, or a named field: span the fields themselves.
+        fields => Err(syn::Error::new_spanned(fields, HELP)),
+    }
+}
+
 // Built and consumed exactly once per derive expansion, so the size gap between
 // the unit variants and `InnerType`'s `syn::Type` is irrelevant here.
 #[expect(clippy::large_enum_variant)]
@@ -252,6 +264,18 @@ fn parse_try_from(ast: &syn::DeriveInput) -> syn::Result<TryFromAttr> {
     for attr in &ast.attrs {
         if !attr.path().is_ident("diesel_newtype") {
             continue;
+        }
+        // Catch `#[diesel_newtype]` and `#[diesel_newtype()]` up front: syn's
+        // own error for these ("unexpected end of input") is opaque, so point
+        // the user at the real syntax instead.
+        match &attr.meta {
+            syn::Meta::List(list) if !list.tokens.is_empty() => {}
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "empty `#[diesel_newtype]` does nothing; write `#[diesel_newtype(try_from = Type)]`",
+                ))
+            }
         }
         attr.parse_nested_meta(|meta| {
             if meta.path.is_ident("try_from") {

--- a/tests/compile-fail.rs
+++ b/tests/compile-fail.rs
@@ -1,0 +1,17 @@
+//! Snapshot tests for the compile errors `#[derive(DieselNewType)]` produces
+//! for misuse (wrong shape, malformed attributes). Gated behind the `ui`
+//! feature because trybuild `.stderr` snapshots are toolchain-specific; see the
+//! `ui` feature comment in Cargo.toml. Run with:
+//!
+//!   cargo +1.84.0 test --features ui
+//!
+//! and regenerate snapshots after intentional message changes with:
+//!
+//!   TRYBUILD=overwrite cargo +1.84.0 test --features ui
+#![cfg(feature = "ui")]
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/tests/try-from.rs
+++ b/tests/try-from.rs
@@ -1,0 +1,140 @@
+//! Tests for `#[diesel_newtype(try_from = Type)]`, which deserializes the
+//! inner type from the database and then `.try_into()`s the newtype so that
+//! invariants are upheld when reading (an invalid value can't be constructed
+//! from SQL).
+
+use std::convert::TryFrom;
+use std::fmt;
+
+use diesel::dsl::sql;
+use diesel::prelude::*;
+use diesel::sqlite::SqliteConnection;
+use diesel_derive_newtype::DieselNewType;
+
+/// A newtype whose inner field is private and can only hold even numbers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, DieselNewType)]
+#[diesel_newtype(try_from = i32)]
+pub struct Even(i32);
+
+#[derive(Debug, PartialEq)]
+pub struct NotEven(i32);
+
+impl fmt::Display for NotEven {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} is not even", self.0)
+    }
+}
+
+impl std::error::Error for NotEven {}
+
+impl TryFrom<i32> for Even {
+    type Error = NotEven;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        if value % 2 == 0 {
+            Ok(Even(value))
+        } else {
+            Err(NotEven(value))
+        }
+    }
+}
+
+/// A newtype using the bare `#[diesel_newtype(try_from)]` (intermediate type
+/// defaults to the field type) *and* an infallible `From` conversion — proving
+/// bare-form parsing works and that `try_from` covers the infallible case too
+/// (via the std `Into` -> `TryInto` blanket impls).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, DieselNewType)]
+#[diesel_newtype(try_from)]
+pub struct Doubled(i32);
+
+impl From<i32> for Doubled {
+    fn from(value: i32) -> Self {
+        Doubled(value)
+    }
+}
+
+table! {
+    numbers {
+        id -> Integer,
+        even -> Integer,
+        doubled -> Integer,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Insertable)]
+#[diesel(table_name = numbers)]
+struct NewNumber {
+    id: i32,
+    even: Even,
+    doubled: Doubled,
+}
+
+fn setup() -> SqliteConnection {
+    let mut conn = SqliteConnection::establish(":memory:").unwrap();
+    let setup = sql::<diesel::sql_types::Bool>(
+        "CREATE TABLE numbers (
+                id INTEGER PRIMARY KEY,
+                even INTEGER NOT NULL,
+                doubled INTEGER NOT NULL
+         )",
+    );
+    setup.execute(&mut conn).expect("Can't create table");
+    conn
+}
+
+fn insert_even(conn: &mut SqliteConnection, id: i32, raw: i32) {
+    // Insert a raw i32 directly so we can control (in)validity.
+    sql::<diesel::sql_types::Bool>(&format!(
+        "INSERT INTO numbers (id, even, doubled) VALUES ({id}, {raw}, {raw})"
+    ))
+    .execute(conn)
+    .expect("insert failed");
+}
+
+#[test]
+fn valid_value_roundtrips() {
+    let mut conn = setup();
+    let obj = NewNumber {
+        id: 1,
+        even: Even(10),
+        doubled: Doubled(3),
+    };
+    diesel::insert_into(numbers::table)
+        .values(&obj)
+        .execute(&mut conn)
+        .expect("insert failed");
+
+    let evens: Vec<Even> = numbers::table
+        .select(numbers::even)
+        .load(&mut conn)
+        .expect("load failed");
+    assert_eq!(evens, vec![Even(10)]);
+}
+
+#[test]
+fn invalid_value_fails_to_deserialize() {
+    let mut conn = setup();
+    insert_even(&mut conn, 1, 7); // 7 is odd -> Even::try_from must reject it
+
+    let result: QueryResult<Vec<Even>> =
+        numbers::table.select(numbers::even).load(&mut conn);
+
+    let err = result.expect_err("odd value must not deserialize into Even");
+    assert!(
+        err.to_string().contains("is not even"),
+        "typed conversion error should be preserved, got: {}",
+        err
+    );
+}
+
+#[test]
+fn infallible_from_conversion_works() {
+    let mut conn = setup();
+    insert_even(&mut conn, 1, 42);
+
+    let doubled: Vec<Doubled> = numbers::table
+        .select(numbers::doubled)
+        .load(&mut conn)
+        .expect("load failed");
+    assert_eq!(doubled, vec![Doubled(42)]);
+}

--- a/tests/ui/bare_attr.rs
+++ b/tests/ui/bare_attr.rs
@@ -1,0 +1,7 @@
+use diesel_derive_newtype::DieselNewType;
+
+#[derive(DieselNewType)]
+#[diesel_newtype]
+struct BareAttr(i64);
+
+fn main() {}

--- a/tests/ui/bare_attr.stderr
+++ b/tests/ui/bare_attr.stderr
@@ -1,0 +1,5 @@
+error: empty `#[diesel_newtype]` does nothing; write `#[diesel_newtype(try_from = Type)]`
+ --> tests/ui/bare_attr.rs:4:1
+  |
+4 | #[diesel_newtype]
+  | ^^^^^^^^^^^^^^^^^

--- a/tests/ui/duplicate_try_from.rs
+++ b/tests/ui/duplicate_try_from.rs
@@ -1,0 +1,7 @@
+use diesel_derive_newtype::DieselNewType;
+
+#[derive(DieselNewType)]
+#[diesel_newtype(try_from = i64, try_from = i64)]
+struct DupTryFrom(i64);
+
+fn main() {}

--- a/tests/ui/duplicate_try_from.stderr
+++ b/tests/ui/duplicate_try_from.stderr
@@ -1,0 +1,5 @@
+error: duplicate `try_from` in #[diesel_newtype(...)]
+ --> tests/ui/duplicate_try_from.rs:4:34
+  |
+4 | #[diesel_newtype(try_from = i64, try_from = i64)]
+  |                                  ^^^^^^^^

--- a/tests/ui/empty_parens.rs
+++ b/tests/ui/empty_parens.rs
@@ -1,0 +1,7 @@
+use diesel_derive_newtype::DieselNewType;
+
+#[derive(DieselNewType)]
+#[diesel_newtype()]
+struct EmptyParens(i64);
+
+fn main() {}

--- a/tests/ui/empty_parens.stderr
+++ b/tests/ui/empty_parens.stderr
@@ -1,0 +1,5 @@
+error: empty `#[diesel_newtype]` does nothing; write `#[diesel_newtype(try_from = Type)]`
+ --> tests/ui/empty_parens.rs:4:1
+  |
+4 | #[diesel_newtype()]
+  | ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/enum.rs
+++ b/tests/ui/enum.rs
@@ -1,0 +1,9 @@
+use diesel_derive_newtype::DieselNewType;
+
+#[derive(DieselNewType)]
+enum Color {
+    Red,
+    Green,
+}
+
+fn main() {}

--- a/tests/ui/enum.stderr
+++ b/tests/ui/enum.stderr
@@ -1,0 +1,5 @@
+error: #[derive(DieselNewType)] can only be used on a tuple struct with exactly one field, e.g. `struct Foo(i64);`
+ --> tests/ui/enum.rs:4:6
+  |
+4 | enum Color {
+  |      ^^^^^

--- a/tests/ui/named_field.rs
+++ b/tests/ui/named_field.rs
@@ -1,0 +1,8 @@
+use diesel_derive_newtype::DieselNewType;
+
+#[derive(DieselNewType)]
+struct Named {
+    value: i64,
+}
+
+fn main() {}

--- a/tests/ui/named_field.stderr
+++ b/tests/ui/named_field.stderr
@@ -1,0 +1,8 @@
+error: #[derive(DieselNewType)] can only be used on a tuple struct with exactly one field, e.g. `struct Foo(i64);`
+ --> tests/ui/named_field.rs:4:14
+  |
+4 |   struct Named {
+  |  ______________^
+5 | |     value: i64,
+6 | | }
+  | |_^

--- a/tests/ui/two_fields.rs
+++ b/tests/ui/two_fields.rs
@@ -1,0 +1,6 @@
+use diesel_derive_newtype::DieselNewType;
+
+#[derive(DieselNewType)]
+struct TwoFields(i64, i64);
+
+fn main() {}

--- a/tests/ui/two_fields.stderr
+++ b/tests/ui/two_fields.stderr
@@ -1,0 +1,5 @@
+error: #[derive(DieselNewType)] can only be used on a tuple struct with exactly one field, e.g. `struct Foo(i64);`
+ --> tests/ui/two_fields.rs:4:17
+  |
+4 | struct TwoFields(i64, i64);
+  |                 ^^^^^^^^^^

--- a/tests/ui/unit_struct.rs
+++ b/tests/ui/unit_struct.rs
@@ -1,0 +1,6 @@
+use diesel_derive_newtype::DieselNewType;
+
+#[derive(DieselNewType)]
+struct Unit;
+
+fn main() {}

--- a/tests/ui/unit_struct.stderr
+++ b/tests/ui/unit_struct.stderr
@@ -1,0 +1,5 @@
+error: #[derive(DieselNewType)] can only be used on a tuple struct with exactly one field, e.g. `struct Foo(i64);`
+ --> tests/ui/unit_struct.rs:4:8
+  |
+4 | struct Unit;
+  |        ^^^^

--- a/tests/ui/unknown_key.rs
+++ b/tests/ui/unknown_key.rs
@@ -1,0 +1,7 @@
+use diesel_derive_newtype::DieselNewType;
+
+#[derive(DieselNewType)]
+#[diesel_newtype(bogus = i64)]
+struct UnknownKey(i64);
+
+fn main() {}

--- a/tests/ui/unknown_key.stderr
+++ b/tests/ui/unknown_key.stderr
@@ -1,0 +1,5 @@
+error: unsupported #[diesel_newtype(...)] key, expected `try_from` or `try_from = Type`
+ --> tests/ui/unknown_key.rs:4:18
+  |
+4 | #[diesel_newtype(bogus = i64)]
+  |                  ^^^^^

--- a/tests/ui/zero_fields.rs
+++ b/tests/ui/zero_fields.rs
@@ -1,0 +1,6 @@
+use diesel_derive_newtype::DieselNewType;
+
+#[derive(DieselNewType)]
+struct ZeroFields();
+
+fn main() {}

--- a/tests/ui/zero_fields.stderr
+++ b/tests/ui/zero_fields.stderr
@@ -1,0 +1,5 @@
+error: #[derive(DieselNewType)] can only be used on a tuple struct with exactly one field, e.g. `struct Foo(i64);`
+ --> tests/ui/zero_fields.rs:4:18
+  |
+4 | struct ZeroFields();
+  |                  ^^


### PR DESCRIPTION
Lets a newtype uphold its invariants when read from the database: the read
path (`FromSql`/`Queryable`) deserializes `InnerType` and calls `.try_into()`
to build the newtype, so construction can fail.

Follows diesel's `deserialize_as` idiom (`.try_into()`) which means we
don't need serde's `from`/`try_from` split. An infallible `From` works
too and the conversion error is preserved but converted into `Box<dyn
Error + Send + Sync>` since that's Diesel's API.

Closes #12.

Additionally use syn::Span:error instead of panic.